### PR TITLE
Fix CI for image_annotate()

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -62,6 +62,7 @@ jobs:
           do
             eval sudo $cmd
           done < <(Rscript -e 'writeLines(remotes::system_requirements("ubuntu", "20.04"))')
+          sudo apt-get install -y gsfonts
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
I think you can remove this workaround again when https://github.com/rstudio/r-system-requirements/pull/82 is merged.