### PR TITLE
fix: Filter NULLs in 'scene_from_list()'

### DIFF
--- a/R/scene_from_list.R
+++ b/R/scene_from_list.R
@@ -36,6 +36,7 @@
 #'                    light_info = directional_light(c(-0.6,1,0.6)))
 #'}
 scene_from_list = function(scene_list) {
+  scene_list = Filter(Negate(is.null), scene_list)
   n = length(scene_list)
   n_shapes = 0L
   


### PR DESCRIPTION
* `scene_from_list()` now filters out any NULLs in the `scene_list`
* `scene_from_list(list(NULL))` no longer throws an ERROR. It did not throw an ERROR in the previous CRAN release and would allow `NULL`s to serve as a de facto "null" mesh.

closes #11